### PR TITLE
remove deprecated @Override to support 0.47

### DIFF
--- a/android/src/main/java/com/github/yamill/orientation/OrientationPackage.java
+++ b/android/src/main/java/com/github/yamill/orientation/OrientationPackage.java
@@ -22,7 +22,7 @@ public class OrientationPackage implements ReactPackage {
         );
     }
 
-    @Override
+    // Deprecated in RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-screen-orientation",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Listen to device orientation changes in react-native and set preferred orientation on screen to screen basis",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This change is backwards compatible with older versions of react-native.